### PR TITLE
Remove step to set repo URL in workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -16,10 +16,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      
-      - name: Set repo URL
-        run: echo "https://github.com/${{ github.repository }}" >> repository.url
-        working-directory: docker
 
       - name: Login to GitHub Docker Registry
         uses: docker/login-action@v1 


### PR DESCRIPTION
Since we now get the source code from the host, we don't need this anymore﻿
