### PR TITLE
removed the INIT from ux_step_smr_claiming_message 

### DIFF
--- a/src/ui/nano/flow_user_confirm_transaction.c
+++ b/src/ui/nano/flow_user_confirm_transaction.c
@@ -219,10 +219,9 @@ UX_STEP_NOCB(
     }
 );
 
-UX_STEP_NOCB_INIT(
+UX_STEP_NOCB(
     ux_step_smr_claiming_message,
     bn_paging,
-    cb_address_preinit(),
     {
         "Claim SMR", "In order to claim SMR coins, you are now "
                      "signing with IOTA private keys instead of SMR "


### PR DESCRIPTION
The claiming message is just a message with fixed content, therefore it was wrong to add a pre-init function that initialized address data.

INIT was removed