### PR TITLE
use crypto helpers to simplify signing and generating addresses

### DIFF
--- a/src/crypto_helpers/crypto_helpers.c
+++ b/src/crypto_helpers/crypto_helpers.c
@@ -1,0 +1,201 @@
+/*****************************************************************************
+ *   Ledger SDK.
+ *   (c) 2023 Ledger SAS.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *****************************************************************************/
+#include <stdint.h>   // uint*_t
+#include <string.h>   // memset, explicit_bzero
+#include <stdbool.h>  // bool
+
+#include "cx.h"
+#include "os.h"
+
+WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_init_privkey_256(
+        unsigned int derivation_mode,
+        cx_curve_t curve,
+        const uint32_t *path,
+        size_t path_len,
+        cx_ecfp_256_private_key_t *privkey,
+        uint8_t *chain_code,
+        unsigned char *seed,
+        size_t seed_len) {
+    cx_err_t error = CX_OK;
+    uint8_t raw_privkey[64]; // Allocate 64 bytes to respect Syscall API but only 32 will be used
+    size_t length;
+
+    // Check curve key length
+    CX_CHECK(cx_ecdomain_parameters_length(curve, &length));
+    if (length != 32) {
+        error = CX_EC_INVALID_CURVE;
+        goto end;
+    }
+
+    // Derive private key according to BIP32 path
+    CX_CHECK(os_derive_bip32_with_seed_no_throw(derivation_mode,
+                                                curve,
+                                                path,
+                                                path_len,
+                                                raw_privkey,
+                                                chain_code,
+                                                seed,
+                                                seed_len));
+
+    // Init privkey from raw
+    CX_CHECK(cx_ecfp_init_private_key_no_throw(curve, raw_privkey, length, privkey));
+
+end:
+    explicit_bzero(raw_privkey, sizeof(raw_privkey));
+
+    if (error != CX_OK) {
+        // Make sure the caller doesn't use uninitialized data in case
+        // the return code is not checked.
+        explicit_bzero(privkey, sizeof(cx_ecfp_256_private_key_t));
+    }
+    return error;
+}
+
+WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_get_pubkey_256(
+        unsigned int derivation_mode,
+        cx_curve_t curve,
+        const uint32_t *path,
+        size_t path_len,
+        uint8_t raw_pubkey[static 65],
+        uint8_t *chain_code,
+        cx_md_t hashID,
+        unsigned char *seed,
+        size_t seed_len) {
+    cx_err_t error = CX_OK;
+
+    cx_ecfp_256_private_key_t privkey;
+    cx_ecfp_256_public_key_t pubkey;
+
+    // Derive private key according to BIP32 path
+    CX_CHECK(bip32_derive_with_seed_init_privkey_256(derivation_mode,
+                                                     curve,
+                                                     path,
+                                                     path_len,
+                                                     &privkey,
+                                                     chain_code,
+                                                     seed,
+                                                     seed_len));
+
+    // Generate associated pubkey
+    CX_CHECK(cx_ecfp_generate_pair2_no_throw(curve, &pubkey, &privkey, true, hashID));
+
+    // Check pubkey length then copy it to raw_pubkey
+    if (pubkey.W_len != 65) {
+        error = CX_EC_INVALID_CURVE;
+        goto end;
+    }
+    memmove(raw_pubkey, pubkey.W, pubkey.W_len);
+
+end:
+    explicit_bzero(&privkey, sizeof(privkey));
+
+    if (error != CX_OK) {
+        // Make sure the caller doesn't use uninitialized data in case
+        // the return code is not checked.
+        explicit_bzero(raw_pubkey, 65);
+    }
+    return error;
+}
+
+WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_ecdsa_sign_hash_256(
+        unsigned int derivation_mode,
+        cx_curve_t curve,
+        const uint32_t *path,
+        size_t path_len,
+        uint32_t sign_mode,
+        cx_md_t hashID,
+        const uint8_t *hash,
+        size_t hash_len,
+        uint8_t *sig,
+        size_t *sig_len,
+        uint32_t *info,
+        unsigned char *seed,
+        size_t seed_len) {
+    cx_err_t error = CX_OK;
+    cx_ecfp_256_private_key_t privkey;
+    size_t buf_len = *sig_len;
+
+    // Derive private key according to BIP32 path
+    CX_CHECK(bip32_derive_with_seed_init_privkey_256(derivation_mode,
+                                                     curve,
+                                                     path,
+                                                     path_len,
+                                                     &privkey,
+                                                     NULL,
+                                                     seed,
+                                                     seed_len));
+
+    CX_CHECK(cx_ecdsa_sign_no_throw(&privkey, sign_mode, hashID, hash, hash_len, sig, sig_len, info));
+
+end:
+    explicit_bzero(&privkey, sizeof(privkey));
+
+    if (error != CX_OK) {
+        // Make sure the caller doesn't use uninitialized data in case
+        // the return code is not checked.
+        explicit_bzero(sig, buf_len);
+    }
+    return error;
+}
+
+WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_eddsa_sign_hash_256(
+        unsigned int derivation_mode,
+        cx_curve_t curve,
+        const uint32_t *path,
+        size_t path_len,
+        cx_md_t hashID,
+        const uint8_t *hash,
+        size_t hash_len,
+        uint8_t *sig,
+        size_t *sig_len,
+        unsigned char *seed,
+        size_t seed_len) {
+    cx_err_t error = CX_OK;
+    cx_ecfp_256_private_key_t privkey;
+    size_t size;
+    size_t buf_len = *sig_len;
+
+    if (sig_len == NULL) {
+        error = CX_INVALID_PARAMETER_VALUE;
+        goto end;
+    }
+
+    // Derive private key according to BIP32 path
+    CX_CHECK(bip32_derive_with_seed_init_privkey_256(derivation_mode,
+                                                     curve,
+                                                     path,
+                                                     path_len,
+                                                     &privkey,
+                                                     NULL,
+                                                     seed,
+                                                     seed_len));
+
+    CX_CHECK(cx_eddsa_sign_no_throw(&privkey, hashID, hash, hash_len, sig, *sig_len));
+
+    CX_CHECK(cx_ecdomain_parameters_length(curve, &size));
+    *sig_len = size * 2;
+
+end:
+    explicit_bzero(&privkey, sizeof(privkey));
+
+    if (error != CX_OK) {
+        // Make sure the caller doesn't use uninitialized data in case
+        // the return code is not checked.
+        explicit_bzero(sig, buf_len);
+    }
+    return error;
+}

--- a/src/crypto_helpers/crypto_helpers.h
+++ b/src/crypto_helpers/crypto_helpers.h
@@ -1,0 +1,301 @@
+#pragma once
+
+#include <stdint.h> // uint*_t
+
+#include "os.h"
+#include "cx.h"
+
+/**
+ * @brief   Gets the private key from the device seed using the specified bip32
+ * path and seed key.
+ *
+ * @param[in]  derivation_mode Derivation mode, one of HDW_NORMAL /
+ * HDW_ED25519_SLIP10 / HDW_SLIP21.
+ *
+ * @param[in]  curve           Curve identifier.
+ *
+ * @param[in]  path            Bip32 path to use for derivation.
+ *
+ * @param[in]  path_len        Bip32 path length.
+ *
+ * @param[out] privkey         Generated private key.
+ *
+ * @param[out] chain_code      Buffer where to store the chain code. Can be
+ * NULL.
+ *
+ * @param[in]  seed            Seed key to use for derivation.
+ *
+ * @param[in]  seed_len        Seed key length.
+ *
+ * @return                     Error code:
+ *                             - CX_OK on success
+ *                             - CX_EC_INVALID_CURVE
+ *                             - CX_INTERNAL_ERROR
+ */
+WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_init_privkey_256(
+    unsigned int derivation_mode, cx_curve_t curve, const uint32_t *path,
+    size_t path_len, cx_ecfp_256_private_key_t *privkey, uint8_t *chain_code,
+    unsigned char *seed, size_t seed_len);
+
+/**
+ * @brief   Gets the private key from the device seed using the specified bip32
+ * path.
+ *
+ * @param[in]  curve           Curve identifier.
+ *
+ * @param[in]  path            Bip32 path to use for derivation.
+ *
+ * @param[in]  path_len        Bip32 path length.
+ *
+ * @param[out] privkey         Generated private key.
+ *
+ * @param[out] chain_code      Buffer where to store the chain code. Can be
+ * NULL.
+ *
+ * @return                     Error code:
+ *                             - CX_OK on success
+ *                             - CX_EC_INVALID_CURVE
+ *                             - CX_INTERNAL_ERROR
+ */
+WARN_UNUSED_RESULT static inline cx_err_t bip32_derive_init_privkey_256(
+    cx_curve_t curve, const uint32_t *path, size_t path_len,
+    cx_ecfp_256_private_key_t *privkey, uint8_t *chain_code)
+{
+    return bip32_derive_with_seed_init_privkey_256(
+        HDW_NORMAL, curve, path, path_len, privkey, chain_code, NULL, 0);
+}
+
+/**
+ * @brief   Gets the public key from the device seed using the specified bip32
+ * path and seed key.
+ *
+ * @param[in]  derivation_mode Derivation mode, one of HDW_NORMAL /
+ * HDW_ED25519_SLIP10 / HDW_SLIP21.
+ *
+ * @param[in]  curve           Curve identifier.
+ *
+ * @param[in]  path            Bip32 path to use for derivation.
+ *
+ * @param[in]  path_len        Bip32 path length.
+ *
+ * @param[out] raw_pubkey      Buffer where to store the public key.
+ *
+ * @param[out] chain_code      Buffer where to store the chain code. Can be
+ * NULL.
+ *
+ * @param[in]  hashID          Message digest algorithm identifier.
+ *
+ * @param[in]  seed            Seed key to use for derivation.
+ *
+ * @param[in]  seed_len        Seed key length.
+ *
+ * @return                     Error code:
+ *                             - CX_OK on success
+ *                             - CX_EC_INVALID_CURVE
+ *                             - CX_INTERNAL_ERROR
+ */
+WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_get_pubkey_256(
+    unsigned int derivation_mode, cx_curve_t curve, const uint32_t *path,
+    size_t path_len, uint8_t raw_pubkey[static 65], uint8_t *chain_code,
+    cx_md_t hashID, unsigned char *seed, size_t seed_len);
+
+/**
+ * @brief   Gets the public key from the device seed using the specified bip32
+ * path.
+ *
+ * @param[in]  curve           Curve identifier.
+ *
+ * @param[in]  path            Bip32 path to use for derivation.
+ *
+ * @param[in]  path_len        Bip32 path length.
+ *
+ * @param[out] raw_pubkey      Buffer where to store the public key.
+ *
+ * @param[out] chain_code      Buffer where to store the chain code. Can be
+ * NULL.
+ *
+ * @param[in]  hashID          Message digest algorithm identifier.
+ *
+ * @return                     Error code:
+ *                             - CX_OK on success
+ *                             - CX_EC_INVALID_CURVE
+ *                             - CX_INTERNAL_ERROR
+ */
+WARN_UNUSED_RESULT static inline cx_err_t
+bip32_derive_get_pubkey_256(cx_curve_t curve, const uint32_t *path,
+                            size_t path_len, uint8_t raw_pubkey[static 65],
+                            uint8_t *chain_code, cx_md_t hashID)
+{
+    return bip32_derive_with_seed_get_pubkey_256(HDW_NORMAL, curve, path,
+                                                 path_len, raw_pubkey,
+                                                 chain_code, hashID, NULL, 0);
+}
+
+/**
+ * @brief   Sign a hash with ecdsa using the device seed derived from the
+ * specified bip32 path and seed key.
+ *
+ * @param[in]  derivation_mode Derivation mode, one of HDW_NORMAL /
+ * HDW_ED25519_SLIP10 / HDW_SLIP21.
+ *
+ * @param[in]  curve           Curve identifier.
+ *
+ * @param[in]  path            Bip32 path to use for derivation.
+ *
+ * @param[in]  path_len        Bip32 path length.
+ *
+ * @param[in]  hashID          Message digest algorithm identifier.
+ *
+ * @param[in]  hash            Digest of the message to be signed.
+ *                             The length of *hash* must be shorter than the
+ * group order size. Otherwise it is truncated.
+ *
+ * @param[in]  hash_len        Length of the digest in octets.
+ *
+ * @param[out] sig             Buffer where to store the signature.
+ *                             The signature is encoded in TLV:  **30 || L || 02
+ * || Lr || r || 02 || Ls || s**
+ *
+ * @param[in]  sig_len         Length of the signature buffer, updated with
+ * signature length.
+ *
+ * @param[out] info            Set with CX_ECCINFO_PARITY_ODD if the
+ * y-coordinate is odd when computing **[k].G**.
+ *
+ * @param[in]  seed            Seed key to use for derivation.
+ *
+ * @param[in]  seed_len        Seed key length.
+ *
+ * @return                     Error code:
+ *                             - CX_OK on success
+ *                             - CX_EC_INVALID_CURVE
+ *                             - CX_INTERNAL_ERROR
+ */
+WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_ecdsa_sign_hash_256(
+    unsigned int derivation_mode, cx_curve_t curve, const uint32_t *path,
+    size_t path_len, uint32_t sign_mode, cx_md_t hashID, const uint8_t *hash,
+    size_t hash_len, uint8_t *sig, size_t *sig_len, uint32_t *info,
+    unsigned char *seed, size_t seed_len);
+
+/**
+ * @brief   Sign a hash with ecdsa using the device seed derived from the
+ * specified bip32 path.
+ *
+ * @param[in]  derivation_mode Derivation mode, one of HDW_NORMAL /
+ * HDW_ED25519_SLIP10 / HDW_SLIP21.
+ *
+ * @param[in]  curve           Curve identifier.
+ *
+ * @param[in]  path            Bip32 path to use for derivation.
+ *
+ * @param[in]  path_len        Bip32 path length.
+ *
+ * @param[in]  hashID          Message digest algorithm identifier.
+ *
+ * @param[in]  hash            Digest of the message to be signed.
+ *                             The length of *hash* must be shorter than the
+ * group order size. Otherwise it is truncated.
+ *
+ * @param[in]  hash_len        Length of the digest in octets.
+ *
+ * @param[out] sig             Buffer where to store the signature.
+ *                             The signature is encoded in TLV:  **30 || L || 02
+ * || Lr || r || 02 || Ls || s**
+ *
+ * @param[in]  sig_len         Length of the signature buffer, updated with
+ * signature length.
+ *
+ * @param[out] info            Set with CX_ECCINFO_PARITY_ODD if the
+ * y-coordinate is odd when computing **[k].G**.
+ *
+ * @return                     Error code:
+ *                             - CX_OK on success
+ *                             - CX_EC_INVALID_CURVE
+ *                             - CX_INTERNAL_ERROR
+ */
+WARN_UNUSED_RESULT static inline cx_err_t bip32_derive_ecdsa_sign_hash_256(
+    cx_curve_t curve, const uint32_t *path, size_t path_len, uint32_t sign_mode,
+    cx_md_t hashID, const uint8_t *hash, size_t hash_len, uint8_t *sig,
+    size_t *sig_len, uint32_t *info)
+{
+    return bip32_derive_with_seed_ecdsa_sign_hash_256(
+        HDW_NORMAL, curve, path, path_len, sign_mode, hashID, hash, hash_len,
+        sig, sig_len, info, NULL, 0);
+}
+
+/**
+ * @brief   Sign a hash with eddsa using the device seed derived from the
+ * specified bip32 path and seed key.
+ *
+ * @param[in]  derivation_mode Derivation mode, one of HDW_NORMAL /
+ * HDW_ED25519_SLIP10 / HDW_SLIP21.
+ *
+ * @param[in]  curve           Curve identifier.
+ *
+ * @param[in]  path            Bip32 path to use for derivation.
+ *
+ * @param[in]  path_len        Bip32 path length.
+ *
+ * @param[in]  hashID          Message digest algorithm identifier.
+ *
+ * @param[in]  hash            Digest of the message to be signed.
+ *                             The length of *hash* must be shorter than the
+ * group order size. Otherwise it is truncated.
+ *
+ * @param[in]  hash_len        Length of the digest in octets.
+ *
+ * @param[out] sig             Buffer where to store the signature.
+ *
+ * @param[in]  sig_len         Length of the signature buffer, updated with
+ * signature length.
+ *
+ * @param[in]  seed            Seed key to use for derivation.
+ *
+ * @param[in]  seed_len        Seed key length.
+ *
+ * @return                     Error code:
+ *                             - CX_OK on success
+ *                             - CX_EC_INVALID_CURVE
+ *                             - CX_INTERNAL_ERROR
+ */
+WARN_UNUSED_RESULT cx_err_t bip32_derive_with_seed_eddsa_sign_hash_256(
+    unsigned int derivation_mode, cx_curve_t curve, const uint32_t *path,
+    size_t path_len, cx_md_t hashID, const uint8_t *hash, size_t hash_len,
+    uint8_t *sig, size_t *sig_len, unsigned char *seed, size_t seed_len);
+
+/**
+ * @brief   Sign a hash with eddsa using the device seed derived from the
+ * specified bip32 path.
+ *
+ * @param[in]  curve           Curve identifier.
+ *
+ * @param[in]  path            Bip32 path to use for derivation.
+ *
+ * @param[in]  path_len        Bip32 path length.
+ *
+ * @param[in]  hashID          Message digest algorithm identifier.
+ *
+ * @param[in]  hash            Digest of the message to be signed.
+ *                             The length of *hash* must be shorter than the
+ * group order size. Otherwise it is truncated.
+ *
+ * @param[in]  hash_len        Length of the digest in octets.
+ *
+ * @param[out] sig             Buffer where to store the signature.
+ *
+ * @param[in]  sig_len         Length of the signature buffer, updated with
+ * signature length.
+ *
+ * @return                     Error code:
+ *                             - CX_OK on success
+ *                             - CX_EC_INVALID_CURVE
+ *                             - CX_INTERNAL_ERROR
+ */
+WARN_UNUSED_RESULT static inline cx_err_t bip32_derive_eddsa_sign_hash_256(
+    cx_curve_t curve, const uint32_t *path, size_t path_len, cx_md_t hashID,
+    const uint8_t *hash, size_t hash_len, uint8_t *sig, size_t *sig_len)
+{
+    return bip32_derive_with_seed_eddsa_sign_hash_256(
+        HDW_NORMAL, curve, path, path_len, hashID, hash, hash_len, sig, sig_len,
+        NULL, 0);
+}

--- a/src/iota/address.c
+++ b/src/iota/address.c
@@ -14,6 +14,7 @@
 #include "address.h"
 #include "ed25519.h"
 #include "macros.h"
+#include "crypto_helpers/crypto_helpers.h"
 
 #pragma GCC diagnostic error "-Wall"
 #pragma GCC diagnostic error "-Wextra"
@@ -51,23 +52,16 @@ uint8_t address_encode_bech32_hrp(const uint8_t *addr_with_type, char *bech32,
 uint8_t address_generate(uint32_t *bip32_path, uint32_t bip32_path_length,
                          uint8_t *addr)
 {
-    cx_ecfp_private_key_t pk;
-    cx_ecfp_public_key_t pub;
+    uint8_t raw_pubkey[65];
 
-    uint8_t ret = 0;
-
-    ret = ed25519_get_key_pair(bip32_path, bip32_path_length, &pk, &pub);
-
-    // always delete from stack
-    explicit_bzero(&pk, sizeof(pk));
-
-    // ed25519_get_key_pair must succeed
-    MUST(ret);
+    MUST(bip32_derive_with_seed_get_pubkey_256(HDW_ED25519_SLIP10, CX_CURVE_Ed25519, bip32_path,
+                                                 bip32_path_length, raw_pubkey,
+                                                 NULL, CX_SHA512, NULL, 0) == CX_OK);
 
     // convert Ledger pubkey to pubkey bytes
     uint8_t pubkey_bytes[PUBKEY_SIZE_BYTES];
 
-    MUST(ed25519_public_key_to_bytes(&pub, pubkey_bytes));
+    MUST(ed25519_public_key_to_bytes(raw_pubkey, pubkey_bytes));
 
     //	debug_print_hex(pubkey_bytes, 32, 16);
 
@@ -81,6 +75,5 @@ uint8_t address_generate(uint32_t *bip32_path, uint32_t bip32_path_length,
     MUST(cx_hash_no_throw(&blake2b.header, CX_LAST, pubkey_bytes,
                           PUBKEY_SIZE_BYTES, &addr[1],
                           ADDRESS_SIZE_BYTES) == CX_OK);
-
     return 1;
 }

--- a/src/iota/ed25519.c
+++ b/src/iota/ed25519.c
@@ -14,66 +14,14 @@
 #pragma GCC diagnostic error "-Wextra"
 #pragma GCC diagnostic error "-Wmissing-prototypes"
 
-// bip-path
-// 		0x2c'/coin_type'/account'/change'/index'
-
-
-uint8_t ed25519_get_key_pair(uint32_t *bip32_path, uint32_t bip32_path_length,
-                             cx_ecfp_private_key_t *pk,
-                             cx_ecfp_public_key_t *pub)
-{
-    uint8_t keySeed[64];
-
-    // getting the seed to derive and configuring it with SLIP10
-    cx_err_t err = CX_OK;
-    do {
-        err = os_derive_bip32_with_seed_no_throw(
-            HDW_ED25519_SLIP10, CX_CURVE_Ed25519, bip32_path, bip32_path_length,
-            keySeed, NULL, (unsigned char *)"ed25519 seed", 12);
-        if (err != CX_OK) {
-            break;
-        }
-
-        // initializing the private key and public key instance
-        // with selected curve ED25519
-        err = cx_ecfp_init_private_key_no_throw(CX_CURVE_Ed25519, keySeed, 32,
-                                                pk);
-        if (err != CX_OK) {
-            break;
-        }
-
-        err = cx_ecfp_init_public_key_no_throw(CX_CURVE_Ed25519, NULL, 0, pub);
-        if (err != CX_OK) {
-            break;
-        }
-
-        // generating the key pair
-        err = cx_ecfp_generate_pair_no_throw(CX_CURVE_Ed25519, pub, pk, 1);
-    } while (0);
-
-    // resetting the variables to avoid leak
-    explicit_bzero(keySeed, sizeof(keySeed));
-
-    return err == CX_OK;
-}
-
 // reversing the public key and changing the last byte
-uint8_t ed25519_public_key_to_bytes(cx_ecfp_public_key_t *pub, uint8_t *output)
+uint8_t ed25519_public_key_to_bytes(uint8_t raw_pubkey[65], uint8_t output[32])
 {
     for (int i = 0; i < 32; i++) {
-        output[i] = pub->W[64 - i];
+        output[i] = raw_pubkey[64 - i];
     }
-    if (pub->W[32] & 1) {
+    if (raw_pubkey[32] & 1) {
         output[31] |= 0x80;
     }
-    return 1;
-}
-
-uint8_t ed25519_sign(cx_ecfp_private_key_t *privateKey, const uint8_t *msg,
-                     uint32_t msg_length, unsigned char *output)
-{
-    MUST(cx_eddsa_sign_no_throw(privateKey, CX_SHA512, msg, msg_length, output,
-                                CX_SHA512_SIZE) == CX_OK);
-
     return 1;
 }

--- a/src/iota/ed25519.h
+++ b/src/iota/ed25519.h
@@ -2,9 +2,4 @@
 
 #include "os.h"
 
-uint8_t ed25519_public_key_to_bytes(cx_ecfp_public_key_t *pub, uint8_t *output);
-uint8_t ed25519_get_key_pair(uint32_t *bip32_path, uint32_t bip32_path_length,
-                             cx_ecfp_private_key_t *pk,
-                             cx_ecfp_public_key_t *pub);
-uint8_t ed25519_sign(cx_ecfp_private_key_t *privateKey, const uint8_t *msg,
-                     uint32_t msg_length, unsigned char *output);
+uint8_t ed25519_public_key_to_bytes(uint8_t raw_pubkey[65], uint8_t output[32]);

--- a/src/iota/signing.c
+++ b/src/iota/signing.c
@@ -4,6 +4,7 @@
 #include "os.h"
 #include "cx.h"
 #include "api.h"
+#include "crypto_helpers/crypto_helpers.h"
 
 #include "macros.h"
 #include "signing.h"
@@ -22,26 +23,29 @@ static uint16_t sign_signature(SIGNATURE_BLOCK *pBlock,
                                uint32_t *bip32_signing_path,
                                API_INPUT_BIP32_INDEX *input_bip32_index)
 {
-    cx_ecfp_private_key_t pk;
-    cx_ecfp_public_key_t pub;
 
     // overwrite bip32_signing_path
     bip32_signing_path[BIP32_ADDRESS_INDEX] = input_bip32_index->bip32_index;
     bip32_signing_path[BIP32_CHANGE_INDEX] = input_bip32_index->bip32_change;
 
-    uint8_t ret = 0;
-    // create key pair and convert pub key to bytes
-    ret = ed25519_get_key_pair(bip32_signing_path, BIP32_PATH_LEN, &pk, &pub);
-    ret = ret && ed25519_sign(&pk, essence_hash, BLAKE2B_SIZE_BYTES,
-                              pBlock->signature);
+    size_t signature_length = CX_SHA512_SIZE;
 
-    // always delete from stack
-    explicit_bzero(&pk, sizeof(pk));
+    MUST(bip32_derive_with_seed_eddsa_sign_hash_256(
+             HDW_ED25519_SLIP10, CX_CURVE_Ed25519, bip32_signing_path,
+             BIP32_PATH_LEN, CX_SHA512, essence_hash, BLAKE2B_SIZE_BYTES,
+             pBlock->signature, &signature_length, NULL, 0) == CX_OK);
 
-    // ed25519_get_key_pair and ed25519_sign must succeed
-    MUST(ret);
+    MUST(signature_length == SIGNATURE_SIZE_BYTES);
 
-    MUST(ed25519_public_key_to_bytes(&pub, pBlock->public_key));
+    // get pubkey
+    uint8_t raw_pubkey[65];
+
+    MUST(bip32_derive_with_seed_get_pubkey_256(
+             HDW_ED25519_SLIP10, CX_CURVE_Ed25519, bip32_signing_path,
+             BIP32_PATH_LEN, raw_pubkey, NULL, CX_SHA512, NULL, 0) == CX_OK);
+
+    // convert Ledger pubkey to pubkey bytes
+    MUST(ed25519_public_key_to_bytes(raw_pubkey, pBlock->public_key));
 
     return (uint16_t)sizeof(SIGNATURE_BLOCK);
 }


### PR DESCRIPTION
Uses crypto-helpers to simplify signing and address generation (and therefore reducing the risk of doing anything wrong)